### PR TITLE
Remove old snapshot CFG_LIBDIR_RELATIVE-ignoring hack.

### DIFF
--- a/mk/main.mk
+++ b/mk/main.mk
@@ -391,18 +391,10 @@ ifeq ($$(CFG_WINDOWSY_$(3)),1)
 # there's no rpath. Target libraries go under $CFG_LIBDIR_RELATIVE (usually 'lib').
 HLIB_RELATIVE$(1)_H_$(3) = bin
 TROOT$(1)_T_$(2)_H_$(3) = $$(HROOT$(1)_H_$(3))/$$(CFG_LIBDIR_RELATIVE)/rustlib/$(2)
-# Remove the next 3 lines after a snapshot
-ifeq ($(1),0)
-RUSTFLAGS_STAGE0 += -L $$(TROOT$(1)_T_$(2)_H_$(3))/lib
-endif
 
 else
 
-ifeq ($(1),0)
-HLIB_RELATIVE$(1)_H_$(3) = lib
-else
 HLIB_RELATIVE$(1)_H_$(3) = $$(CFG_LIBDIR_RELATIVE)
-endif
 TROOT$(1)_T_$(2)_H_$(3) = $$(HLIB$(1)_H_$(3))/rustlib/$(2)
 
 endif


### PR DESCRIPTION
Unbreaks the build for distributions which use `--libdir=/usr/lib64`, resulting in `CFG_LIBDIR_RELATIVE=lib64` (fixes #32261).

r? @alexcrichton
